### PR TITLE
Apply enable_laser_ param after camera init on legacy devices

### DIFF
--- a/orbbec_camera/include/orbbec_camera/ob_camera_node.h
+++ b/orbbec_camera/include/orbbec_camera/ob_camera_node.h
@@ -145,6 +145,8 @@ class OBCameraNode {
 
   void startIMU();
 
+  void applyLegacyEnableLaserParam();
+
  private:
   struct IMUData {
     IMUData() = default;

--- a/orbbec_camera/src/ob_camera_node_driver.cpp
+++ b/orbbec_camera/src/ob_camera_node_driver.cpp
@@ -307,6 +307,7 @@ void OBCameraNodeDriver::initializeDevice(const std::shared_ptr<ob::Device> &dev
   ob_camera_node_ = std::make_unique<OBCameraNode>(this, device_, parameters_);
   ob_camera_node_->startIMU();
   ob_camera_node_->startStreams();
+  ob_camera_node_->applyLegacyEnableLaserParam();
   device_connected_ = true;
   device_info_ = device_->getDeviceInfo();
   serial_number_ = device_info_->serialNumber();


### PR DESCRIPTION
This PR adds the enable_laser parameter' s functionality on older devices like the Gemini 2 where the `OB_PROP_LASER_CONTROL_INT` property is not supported.

This should be a temporary fix until all cameras are changed to Gemini 330 series which supports the above mentioned parameter.

Simply setting the legacy `OB_PROP_LASER_BOOL` property where OB_PROP_LASER_CONTROL_INT` is set (ob_camera_node.cpp:154) won't work hence a more through refactor could be done where every parameter is considered to be set after the camera initialization, but this sound like something royally out of scope for the problem at hand.